### PR TITLE
Add listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ Once you have your credentials loaded in you can initialise the client:
 (creddit/users-popular creddit-client limit)
 ```
 
+### Listings
+
+*Retrieve specific posts**
+
+**names:** Sequence of fully specified [fullnames](https://www.reddit.com/dev/api#fullnames).
+
+```clojure
+(creddit/listing creddit-client names)
+```
+
 
 ## Development
 

--- a/src/creddit/client.clj
+++ b/src/creddit/client.clj
@@ -201,3 +201,8 @@
   (if (valid-limit? limit)
     (-> (http-get credentials (str "https://www.reddit.com/users/popular/.json?limit=" limit))
         (parse-response))))
+
+(defn listing
+  [credentials names]
+  (-> (http-get credentials (str "https://www.reddit.com/by_id/" (string/join "," names) "/.json"))
+      (parse-response)))

--- a/src/creddit/core.clj
+++ b/src/creddit/core.clj
@@ -25,7 +25,8 @@
   (user-comments [this username limit time])
   (users [this limit])
   (users-new [this limit])
-  (users-popular [this limit]))
+  (users-popular [this limit])
+  (listing [this names]))
 
 (defrecord CredditClient [credentials]
   RedditApi
@@ -52,7 +53,8 @@
   (user-comments [this username limit time] (client/user-comments credentials username limit time))
   (users [this limit] (client/users credentials limit))
   (users-new [this limit] (client/users-new credentials limit))
-  (users-popular [this limit] (client/users-popular credentials limit)))
+  (users-popular [this limit] (client/users-popular credentials limit))
+  (listing [this names] (client/listing credentials names)))
 
 (defn init
   [credentials]

--- a/test/creddit/test/client.clj
+++ b/test/creddit/test/client.clj
@@ -260,3 +260,14 @@
              (client/users-popular creddit-client 10))
            parsed-reddit-response))
     (is (thrown? Exception (client/users-popular creddit-client "10")))))
+
+(deftest test-listing
+  (testing "Retrieve named posts"
+    (is (= (with-fake-routes-in-isolation
+             {"https://www.reddit.com/by_id/t3_7ktt45,t3_7jj5nf/.json"
+              (fn [request]
+                {:status 200 :headers {} :body reddit-response})}
+             (client/listing creddit-client ["t3_7ktt45" "t3_7jj5nf"]))
+           parsed-reddit-response))
+    (is (thrown? Exception (client/listing creddit-client "t3_7jj5nf")))
+    (is (thrown? Exception (client/listing creddit-client :t3_7jj5nf)))))


### PR DESCRIPTION
This is a quick and straightforward way of adding the general listing endpoint—`/by_id/<names>`—which allows one to check on items later and get fresher stats about them.