### PR TITLE
Refactored parse-response #19

### DIFF
--- a/src/creddit/client.clj
+++ b/src/creddit/client.clj
@@ -6,13 +6,9 @@
 
 (defn- parse-response
   [response]
-  (if-let [data (or (get-in response [:data :children])
+  (if-let [coll (or (get-in response [:data :children])
                     (get-in response [:data :trophies]))]
-    (reduce
-      (fn [posts post]
-        (conj posts (:data post)))
-      []
-      data)
+    (map :data coll)
     (:data response)))
 
 (defn- valid-limit? [limit]


### PR DESCRIPTION
1. Simplified `parse-response` function to use map instead of reduce
2. Renamed `data` variable to `coll` to indicate that it is a collection